### PR TITLE
Add example extending Manager Singletons

### DIFF
--- a/ExtendedSingletonClasses/ExampleInvokingNewFeatures.cs
+++ b/ExtendedSingletonClasses/ExampleInvokingNewFeatures.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+using MoreMountains.TopDownEngine;
+
+public class ExampleInvokingNewFeatures : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        // Explicitly define the Singleton Instance from LevelManagerWithFeature as the LevelManagerWithFeature class
+        // Then invoke the new feature
+        // This is quite verbose and redundant, which is why GameManager has a new Singleton accessor
+        ((LevelManagerWithFeature)LevelManagerWithFeature.Instance).NewFeature();
+
+        // Access the Singleton Instance already cast inside the GameManagerWithFeature's ExtendedInstance member
+        GameManagerWithFeature.ExtendedInstance.NewFeature();
+    }
+}

--- a/ExtendedSingletonClasses/GameManagerWithFeature.cs
+++ b/ExtendedSingletonClasses/GameManagerWithFeature.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+namespace MoreMountains.TopDownEngine
+{
+    /// <summary>
+    /// This GameManager will extend the base class and provide new functionality
+    /// It also creates a new ExtendedInstance of the Singleton already cast as the new class
+    /// </summary>
+    public class GameManagerWithFeature : GameManager
+    {
+        // Static extension of Instance property which converts to new class
+        public static GameManagerWithFeature ExtendedInstance => (GameManagerWithFeature) Instance;
+
+        protected override void Start()
+        {
+            Debug.Log("Start was called from extended GameManagerWithFeature");
+            base.Start();
+        }
+
+        public void NewFeature()
+        {
+            Debug.Log("New Feature was invoked in GameManager");
+        }
+    }
+}

--- a/ExtendedSingletonClasses/LevelManagerWithFeature.cs
+++ b/ExtendedSingletonClasses/LevelManagerWithFeature.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+namespace MoreMountains.TopDownEngine
+{
+    /// <summary>
+    /// This LevelManager will extend the base class and provide new functionality
+    /// </summary>
+    public class LevelManagerWithFeature : LevelManager
+    {
+        protected override void Start()
+        {
+            Debug.Log("Start was called from extended LevelManagerWithFeature");
+            base.Start();
+        }
+
+        public void NewFeature()
+        {
+            Debug.Log("New Feature was invoked in LevelManager");
+        }
+    }
+}

--- a/ExtendedSingletonClasses/README.md
+++ b/ExtendedSingletonClasses/README.md
@@ -1,6 +1,6 @@
 ## Extending Singleton Managers
 
-The Engine does a great job making its base classes extendable by virtue of all the methods being `virtual`.  One area that was a bit more difficult to extend was various classes in the `/Managers` folder.  All of the methods are `virtual`, but all the classes are inherit `MMPersistentSingleton` or `MMSingleton`.  They define their `Instance` property as the class type.  This causes some confusion when extending the various Manager classes and trying to continue the Singleton pattern.
+The Engine does a great job making its base classes extendable by virtue of all the methods being `virtual`.  One area that was a bit more difficult to extend was various classes in the `/Managers` folder.  All of the methods are `virtual`, but all the classes are derived from `MMPersistentSingleton` or `MMSingleton`.  They define their `Instance` property as the class type.  This causes some confusion when extending the various Manager classes and trying to continue the Singleton pattern.
 
 For example, we can very easily create a class that extends GameManager and replace the base scripts with it
 ```C#

--- a/ExtendedSingletonClasses/README.md
+++ b/ExtendedSingletonClasses/README.md
@@ -1,0 +1,47 @@
+## Extending Singleton Managers
+
+The Engine does a great job making its base classes extendable by virtue of all the methods being `virtual`.  One area that was a bit more difficult to extend was various classes in the `/Managers` folder.  All of the methods are `virtual`, but all the classes are inherit `MMPersistentSingleton` or `MMSingleton`.  They define their `Instance` property as the class type.  This causes some confusion when extending the various Manager classes and trying to continue the Singleton pattern.
+
+For example, we can very easily create a class that extends GameManager and replace the base scripts with it
+```C#
+public class GameManagerWithFeature : GameManager
+{
+    public void NewFeature()
+    {
+        Debug.Log("New Feature was invoked in GameManager");
+    }
+}
+```
+
+Issues arise when trying to access the Instance of the new feature in a different script.  The following will not compile
+```C#
+public class ExampleInvokingNewFeatures : MonoBehaviour
+{
+    void Start()
+    {
+        GameManagerWithFeature.Instance.NewFeature();
+    }
+}
+```
+
+With C# explicit conversions we can access the new feature.  This can be seen by replacing the line in `Start()` with the following
+```C#
+((GameManagerWithFeature)GameManagerWithFeature).Instance.NewFeature();
+```
+
+The code above is verbose to use, and we could instead add a new property on the extended class that casts the Instance for us.  This would look like
+```C#
+public static GameManagerWithFeature ExtendedInstance => (GameManagerWithFeature) Instance;
+```
+
+With this we can replace the line in `Start()` with
+```C#
+GameManagerWithFeature.ExtendedInstance.NewFeature();
+```
+
+### How to use these extended classes
+
+- Replace the `GameManager` script on the GameManager object with the `GameManagerWithFeature`
+- Replace the `LevelManager` script on the LevelManager object with the `LevelManagerWithFeature`
+- Create an empty game object and add the `ExampleInvokingNewFeature` script
+- Run the scene and check the Console for the debug logs

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains community-created extensions for the TopDown Engine, Mo
 * **AI Performance Manager**, _by Force_ : A system used to disable AIs based on distance to the player for better performance
 * **Character8WayGridMovement**, _by @jcphlux_ : adds support for 8-way grid movement.
 * **Control Freak 2 Integration**, _by christougher_ : support for the input solution Control Freak 2, available on the Asset Store.
+* **Extended Singlegon Managers** _by michaelrivet_ : examples of extending singleton Managers
 * **HeldButtonZone**, _by Dougomite_ : a button activated zone for which the player needs to keep the button pressed for a certain duration to activate
 * **MMFeedbackLootDrops**, _by Dougomite_ : an MMFeedback that spawns "loot" (item pickers or any object you want) in a certain radius at weighted chances
 * **MultiInventoryDetails**, _by men8_ : an addon to handle all active inventories on scene. See [this repo](https://github.com/men8/MultiInventoryDetails) for more info.


### PR DESCRIPTION
## Why is this change happening?

When working with TopDownEngine I found almost everything very easy to extend.  The Manager classes which need to be in each scene are also extendable because their methods are `protected virtual`.  The manager classes extend the `MMSingleton` and `MMPersistentSingleton`.  This means fully extending them takes a bit more effort because the `Instance` needs to be explicitly converted to the derived class type.

## Does this actually provide any new logic?

Unlike the other extensions this **does not provide any new logic** out of the box aside from a debug log.  I was working on extending these specific classes and it took a few tries before I could come up with a solution that worked well.  Most of the value of this extension folder is a knowledge share via the readme that I created. ([here](https://github.com/michaelrivet/TopDownEngineExtensions/tree/master/ExtendedSingletonClasses))