### PR TITLE
Fix issue with Stamina updating on wrong target

### DIFF
--- a/Stamina/Stamina.cs
+++ b/Stamina/Stamina.cs
@@ -104,6 +104,8 @@ namespace Stamina
 
         public void OnMMEvent(MMStateChangeEvent<CharacterStates.MovementStates> movementStateChange)
         {
+            if (movementStateChange.Target != gameObject)
+                return;
             if (movementStateChange.NewState != CharacterStates.MovementStates.Running) _running = false;
             switch (movementStateChange.NewState)
             {


### PR DESCRIPTION
Seems like Stamina was updating the movement state on any MovementState event.  Just added a check for self.