### PR TITLE
Add CharacterRunWhenFaceDirection3D

### DIFF
--- a/CharacterRunWhenFaceDirection3D/CharacterRunWhenFaceDirection3D.cs
+++ b/CharacterRunWhenFaceDirection3D/CharacterRunWhenFaceDirection3D.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+using MoreMountains.TopDownEngine;
+
+namespace TopDownEngineExtensions
+{	
+	/// <summary>
+	/// Add this component to a character and it'll be able to run only when the models faces the direction of movement.
+	/// Animator parameters : Running
+	/// </summary>
+	[AddComponentMenu("TopDown Engine/Character/Abilities/Character Run When Face Direction 3D")] 
+	public class CharacterRunWhenFaceDirection3D : CharacterRun
+	{
+		[Header("Permitted Angle")]
+		[SerializeField]
+		[Tooltip("The maximum angle allowed at which the character can run.")]
+		private float AngleThreshold = 45f;
+
+		/// <summary>
+		/// At the beginning of each cycle, we check if we've pressed or released the run button
+		/// </summary>
+		protected override void HandleInput()
+		{
+			base.HandleInput();
+			if(_movement.CurrentState == CharacterStates.MovementStates.Running && !isFacingDirection())
+            {
+				RunStop();
+            }
+		}
+
+		/// <summary>
+		/// Causes the character to start running.
+		/// </summary>
+		public override void RunStart()
+		{
+			if (!isFacingDirection()) return;
+			base.RunStart();
+		}
+
+
+		/// <summary>
+		/// Checks if the character model is facing the movement direction.
+		/// </summary>
+		private bool isFacingDirection()
+        {
+			CharacterOrientation3D orientation = _character.FindAbility<CharacterOrientation3D>();
+
+			Vector3 modelDirection = orientation.ModelDirection.normalized;
+			Vector3 movementDirection = orientation.CurrentDirection.normalized;
+
+			float dotProduct = Vector3.Dot(modelDirection, movementDirection);
+
+			float cosThreshold = Mathf.Cos(AngleThreshold * Mathf.Deg2Rad);
+
+			return dotProduct >= cosThreshold;
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository contains community-created extensions for the TopDown Engine, Mo
 
 * **CharacterInventoryWeaponChanger**, _by AlexanderGheorghe_ : this script allows you to use scroll wheel or number keys to change your weapon to any weapon from your MainInventory
 * **CharacterMultiButtonActivation**, _by AlexanderGheorghe_ : extension of CharacterButtonActivation that lets characters interact with multiple ButtonActivated that they're touching
+* **CharacterRunWhenFaceDirection3D**, _by Aitor F._: Extension of CharacterRun that only permit the Character to run when is facing the movement direction, allowing for a small angular threshold. Useful when using a Weapon with AutoAim or when AimControl is set to Secondary Movement. For example, you can run aiming towards an enemy, but if you aim while moving away you can't.
 * **CharacterWeaponMagazineMemorizer**, _by AlexanderGheorghe_ : Memorize the remaining ammo on the weapon so when switching back to it, it retains the current ammo instead of a full clip.
 * **CharacterOrientation3DExtensions**, _by AlexanderGheorghe_ : extension methods for forcing character orientation towards a transform. includes a usage example in CharacterForceLookAtZone
 * **CharacterProne**, _by AlexanderGheorghe_ : duplicate of CharacterCrouch that allows you to have different animations (Animator parameters "Prone" and "ProneMoving") and different collider resizing, useful for making a character prone like in Metal Gear Solid, for example


### PR DESCRIPTION
Simple script that adds the ability CharacterRunWhenFaceDirection3D, which is an extension of CharacterRun that only permit the Character to run when is facing the movement direction, allowing for a small angular threshold. 

Useful when using a Weapon with AutoAim or when AimControl is set to Secondary Movement. 

For example, you can run aiming towards an enemy, but if you aim while moving away you can't.